### PR TITLE
Add Replicate demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # diffusers/controlnet-canny-sdxl-1.0 Cog model
 
+[![Try a demo on Replicate](https://replicate.com/pnyompen/sd-controlnet-lora/badge)](https://replicate.com/pnyompen/sd-controlnet-lora)
+
 This is an implementation of the [diffusers/controlnet-canny-sdxl-1.0](https://huggingface.co/diffusers/controlnet-canny-sdxl-1.0) as a Cog model. [Cog packages machine learning models as standard containers.](https://github.com/replicate/cog)
 
 First, download the pre-trained weights:


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.